### PR TITLE
Corrigido regexp que checava o código do ticket

### DIFF
--- a/spfblspam.sh
+++ b/spfblspam.sh
@@ -23,7 +23,7 @@
 #  6. Ticket inválido.
 #
 
-if [[ $1 =~ ^[a-zA-Z0-9/+]+$ ]]; then
+if [[ $1 =~ ^[a-zA-Z0-9/+=]+$ ]]; then
 
 	# O parâmentro é um ticket SPFBL.
 	ticket=$1


### PR DESCRIPTION
em alguns casos continha o caracter = (igual) e por isso dava erro para submeter o ticket
