### PR TITLE
spfbl.sh STATS <date>

### DIFF
--- a/client/spfbl.sh
+++ b/client/spfbl.sh
@@ -4021,7 +4021,13 @@ case $1 in
 		# saida em linha de comando
 		#
 
-		TODAY=`date +%Y-%m-%d`
+                # Escolhe a data de log
+                if [[ $2 =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+                        TODAY=$2
+                else
+                        TODAY=`date +%Y-%m-%d`
+                fi
+
 		LOGPATH=/var/log/spfbl/
 
 		BLOCKED=$(grep -c BLOCKED "$LOGPATH"spfbl."$TODAY".log)


### PR DESCRIPTION
Permite analisar logs anteriores utilizando o formato de data do arquivo de LOG.

Sintaxe: spfbl.sh stats <yyyy-mm-dd>
Ex: spfbl.sh stats 2017-02-01