### PR TITLE
Atualiza o subcomando spfbl.sh stats

### DIFF
--- a/client/spfbl.sh
+++ b/client/spfbl.sh
@@ -4358,8 +4358,8 @@ case $1 in
 	}
 
 	criaLogTemp(){
-		egrep " SPFTCP[0-9]+ SPFBL " $LOGFILE > $LOGTEMP
-		egrep " DNSUDP[0-9]+ DNSBL " $LOGFILE > $LOGTEMPDNS
+		egrep -a " SPFTCP[0-9]+ SPFBL " $LOGFILE > $LOGTEMP
+		egrep -a " DNSUDP[0-9]+ DNSBL " $LOGFILE > $LOGTEMPDNS
 	}
 
 	executaStats(){


### PR DESCRIPTION
Na função criaLogTemp() foi adicionada a flag "-a" ao egrep para que ele trate o arquivo de log sempre como texto. Pode haver uma condição em que o log contém o caractere NUL (ex: uma tentativa de ataque com execução de comandos registrada) e, dessa forma, ele seria tratado como binário, ocasionando erro "divide by zero" na execução do spfbl.sh stats. Essa flag previne que isso aconteça.